### PR TITLE
Jdk15ea

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This image was jlinked using the following Java modules, which, to the best of m
 
 # Goals
 
-+ Test using the early access Alpine version of JDK15
++ Run more tests using the early access Alpine version of JDK15
 + Add support for PGP-based signature verification, [despite its shortcomings](https://arstechnica.com/information-technology/2016/12/op-ed-im-giving-up-on-pgp/)
 
 # Source
 
-The build process for the current tag (jdk14) is now nearly entirely automated, but development on other branches is not. Issues are enabled, so if something doesn't work I look forward to the challenge.
+I track my own edits on [GitHub](https://github.com/boner-cmd/jlinkmc). The build process for the current tag (jdk14) is now nearly entirely automated, but development on the jdk15 early access branch is not. Issues are enabled, so if something doesn't work, then I look forward to the challenge of correcting it.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # jlinkmc
 JLinked JDK suitable for use with PaperMC Minecraft
 
-# Size
+# Compressed Size Comparison
 
-(As of 20200424)
+(As of 20200425)
 
-+ Compressed size of ethco/jlinkmc:jdk14 - 75.56 MB
++ ethco/jlinkmc:jdk15ea - 55.14 MB
 
-+ Compressed size of AdoptOpenJDK/openjdk14:alpine - 210.87 MB
++ ethco/jlinkmc:jdk14 - 75.56 MB
+
++ AdoptOpenJDK/openjdk14:alpine - 210.87 MB
 
 # Concept
 
-Using this image to prepare a [PaperMC](https://papermc.io/) or other Minecraft server on an Alpine base can substantially reduce the total size of your image. The code used was based on posts from Matthew Gilliard's blog ([like this one](https://blog.gilliard.lol/2018/11/05/alpine-jdk11-images.html)), themselves based on work on AdoptOpenJDK by Dinakar Guniguntala ([dinogun](https://github.com/dinogun)) and others. As described in the blog post, this is NOT an Alpine-native (Portola) Java build, but a build of Java using [Sasha Gerrand](https://github.com/sgerrand)'s Gnu C library compatibility layer package for Alpine. 
+Using this image to prepare a [PaperMC](https://papermc.io/) or other Minecraft server on an Alpine base can substantially reduce the total size of your image. The code used was based on posts from Matthew Gilliard's blog ([like this one](https://blog.gilliard.lol/2018/11/05/alpine-jdk11-images.html)), themselves based on work on AdoptOpenJDK by Dinakar Guniguntala ([dinogun](https://github.com/dinogun)) and others.
 
-The transition to Portola will hopefully occur when JDK15 reaches general availability, currently scheduled for 15 September, 2020, and will hopefully result in further size reduction.
+The`jdk14` tag is NOT an Alpine-native muslc (Portola) Java build. Instead, it uses [Sasha Gerrand](https://github.com/sgerrand)'s Gnu C library compatibility layer package for Alpine.
+
+The transition to Portola or another muslc build will occur when JDK15 reaches general availability, currently scheduled for 15 September, 2020, and will result in further size reduction. Progress during early access should be considered perpetually unstable, and can be found in the `jdk15ea` tag.
 
 # Contents
 

--- a/ea/Dockerfile
+++ b/ea/Dockerfile
@@ -10,7 +10,7 @@ ENV JDK_FILENAME="openjdk-15-ea+10_linux-x64-musl_bin.tar.gz"
 
 RUN apk update \
   && apk add --no-cache curl binutils libgcc libstdc++ \
-  && curl -LfsS https://download.java.net/java/early_access/alpine/10/binaries/${JDK_FILENAME} -O \
+  && curl -Lf https://download.java.net/java/early_access/alpine/10/binaries/${JDK_FILENAME} -O \
   && tar -xzf ${JDK_FILENAME} \
   && mv jdk-15/* . \
   && rm -r jdk-15 \

--- a/ea/Dockerfile
+++ b/ea/Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine:latest AS jlink
+
+RUN mkdir -p /opt/java/openjdk
+
+WORKDIR /opt/java/openjdk
+
+ENV JDK_FILENAME="openjdk-15-ea+10_linux-x64-musl_bin.tar.gz"
+
+# need to test if binutils, libgcc, and libstdc++ are needed for jlink
+
+RUN apk update \
+  && apk add --no-cache curl binutils libgcc libstdc++ \
+  && curl -LfsS https://download.java.net/java/early_access/alpine/10/binaries/${JDK_FILENAME} -O \
+  && tar -xzf ${JDK_FILENAME} \
+  && mv jdk-15/* . \
+  && rm -r jdk-15 \
+  && rm ${JDK_FILENAME} \
+  && apk del --purge curl
+
+RUN ["/opt/java/openjdk/bin/jlink", "--compress=2", "--bind-services", \
+  "--strip-debug", "--module-path", "/opt/java/openjdk/jmods", \
+  "--add-modules", \
+	"java.base,java.compiler,java.desktop,java.logging,java.management,java.naming,java.rmi,java.scripting,java.sql,java.xml,jdk.sctp,jdk.unsupported,java.instrument", \
+  "--no-header-files", "--no-man-pages", "--output", "/jlinked"]
+
+FROM alpine:latest
+
+COPY --from=jlink /jlinked /opt/java/openjdk
+ENV PATH="/opt/java/openjdk/bin:${PATH}"
+
+CMD ["java", "-version"]


### PR DESCRIPTION
I made a branch for JDK 15 but since its file is in a separate directory and it seems like it worked on the first try (HA HA) there's not a compelling reason not to merge now and continue on the master branch. The file structure _does_ need to be organized better, probably with separate folders for separate tags, even if that entails minimal file duplication. As of right now though, I don't think that would even be the case, yet.