### PR TITLE
check signatures of GCC and ZLIB files

### DIFF
--- a/sandbox/builder
+++ b/sandbox/builder
@@ -66,6 +66,14 @@ main() {
   curl -Lf "${GLIBC_FULL_URL}" "${GLIBC_BIN_URL}" "${GLIBC_I18N_URL}" -O -O -O \
     || exit 1
 
+  curl -LfsS "${GCC_FULL_URL}.sig" "${ZLIB_FULL_URL}.sig" -O -O \
+    || exit 1
+
+  gpg --verify-files "*.sig" \
+    || exit 1
+
+  rm "*.sig"  
+
   declare -a sums
   for file in *; do
     sums+=("$(sha256sum "./${file}" | head -c 64)")


### PR DESCRIPTION
since Sasha Gerrand's RSA key is already used in the APK installation process, the only piece left to resolve #2 was to add gpg key verification to the GCC and ZLIB files, which was trivial.